### PR TITLE
feat: Basic framework for allowing selfhosted servers upon startup via Config

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -151,6 +151,11 @@ const config: ForgeConfig = {
           config: "vite.preload.config.ts",
           target: "preload",
         },
+        {
+          entry: "public/homeserver.html",
+          config: "vite.preload.config.ts",
+          target: "preload",
+        }
       ],
       renderer: [],
     }),

--- a/public/homeserver.html
+++ b/public/homeserver.html
@@ -1,0 +1,182 @@
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="theme-color" content="#000000">
+  <title>Stoat Desktop</title>
+
+  <style>
+    * {
+      box-sizing: border-box
+    }
+
+    body {
+      margin: 0;
+      background: #191919;
+      font-family: Arial, Helvetica, sans-serif;
+    }
+
+    :host {
+      --font-fallback: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+      -webkit-text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      -moz-tab-size: 4;
+      tab-size: 4;
+      -webkit-tap-highlight-color: transparent;
+      line-height: 1.5;
+      font-family: var(--global-font-body, var(--font-fallback))
+    }
+
+    *,
+    ::backdrop,
+    ::file-selector-button,
+    :after,
+    :before {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+      border-width: 0;
+      border-style: solid;
+      border-color: var(--global-color-border, currentColor)
+    }
+
+    body {
+      height: 100%;
+      line-height: inherit
+    }
+
+    svg {
+      display: block;
+      vertical-align: middle
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      text-wrap: balance;
+      font-size: inherit;
+      font-weight: inherit
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+      overflow-wrap: break-word
+    }
+
+    ::file-selector-button,
+    button,
+    input:where([type=button], [type=reset], [type=submit]) {
+      appearance: button;
+      -webkit-appearance: button
+    }
+
+    ::file-selector-button,
+    button,
+    input,
+    select {
+      font: inherit;
+      font-feature-settings: inherit;
+      font-variation-settings: inherit;
+      letter-spacing: inherit;
+      color: inherit;
+      background: var(--colors-transparent)
+    }
+
+    ::placeholder {
+      opacity: 1;
+      --placeholder-fallback: color-mix(in srgb, currentColor 50%, transparent);
+      color: var(--global-color-placeholder, var(--placeholder-fallback))
+    }
+
+    a {
+      color: inherit;
+      text-decoration: inherit
+    }
+
+    b {
+      font-weight: bolder
+    }
+
+    ::-webkit-search-cancel-button,
+    ::-webkit-search-decoration {
+      -webkit-appearance: none
+    }
+
+    ::-webkit-inner-spin-button,
+    ::-webkit-outer-spin-button {
+      height: auto
+    }
+
+    :-moz-ui-invalid {
+      box-shadow: none
+    }
+
+    :-moz-focusring {
+      outline: auto
+    }
+
+    [hidden] {
+      display: none !important
+    }
+  </style>
+
+  <script>
+    function submitHomeserver(e) {
+      desktopConfig.setHomeserver(e.target[0].value);
+    }
+  </script>
+</head>
+
+<body style="background: #1a110f; color: #f1dfdb;">
+  <div style="height: 29px; background: #a08c88; padding: 5px;">
+    <div style="user-select: none; app-region: drag; width: calc(100% - 100px); height: 100%; float: left;"></div>
+    <div style="width: 100px; float: right;">
+      <a style="float: right;" onclick="native.close()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 -960 960 960">
+          <path d="m249-207-42-42 231-231-231-231 42-42 231 231 231-231 42 42-231 231 231 231-42 42-231-231z"></path>
+        </svg>
+      </a>
+      <a style="float: right; margin-right: 10px;" onclick="native.maximise()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 -960 960 960">
+          <path d="M200-200v-240h60v180h180v60zm500-320v-180H520v-60h240v240z"></path>
+        </svg>
+      </a>
+      <a style="float: right; margin-right: 10px;" onclick="native.minimise()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 -960 960 960">
+          <path d="M240-120v-60h481v60z"></path>
+        </svg>
+      </a>
+    </div>
+  </div>
+  <div
+    style="position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); background: #271d1b; border-radius: 2rem; width: 25%; height: 33%; padding: 30px;">
+    <div>
+      <span style="font-size: 1.5rem;">Hello!</span>
+      <p style="font-weight: bold; margin-top: 5px;">Connect to a Stoat Server</p>
+    </div>
+    <form onsubmit="submitHomeserver(event)">
+      <div>
+        <input type="text" name="server" required="" placeholder="Server Address" label="Server"
+          style="background: #3d3230; height: 50px; width: 100%; padding: 10px; color: #ffb4ab; border-bottom: 1px solid #ffb4ab; margin-top: 5px;"
+          value="https://beta.revolt.chat" />
+        <button type="submit"
+          style="background: #ffb4a4; margin-left: 50%; transform: translate(-50%); height: 40px; width: 200px; border-radius: 1rem; margin-top: 20px; color: #561f12; font-weight: bold;">
+          Connect
+        </button>
+      </div>
+    </form>
+  </div>
+</body>
+
+</html>

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -5,6 +5,7 @@ declare type DesktopConfig = {
   spellchecker: boolean;
   hardwareAcceleration: boolean;
   discordRpc: boolean;
+  homeserver: string;
   windowState: {
     isMaximised: boolean;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { autoLaunch } from "./native/autoLaunch";
 import { config } from "./native/config";
 import { initDiscordRpc } from "./native/discordRpc";
 import { initTray } from "./native/tray";
-import { BUILD_URL, createMainWindow, mainWindow } from "./native/window";
+import { createMainWindow, mainWindow } from "./native/window";
 
 // Squirrel-specific logic
 // create/remove shortcuts on Windows when installing / uninstalling
@@ -77,7 +77,7 @@ if (acquiredLock) {
   app.on("web-contents-created", (_, contents) => {
     // prevent navigation out of build URL origin
     contents.on("will-navigate", (event, navigationUrl) => {
-      if (new URL(navigationUrl).origin !== BUILD_URL.origin) {
+      if (new URL(navigationUrl).origin !== config.homeserver) {
         event.preventDefault();
       }
     });

--- a/src/native/config.ts
+++ b/src/native/config.ts
@@ -25,6 +25,9 @@ const schema = {
   discordRpc: {
     type: "boolean",
   } as JSONSchema.Boolean,
+  homeserver: {
+    type: "string"
+  } as JSONSchema.String,
   windowState: {
     type: "object",
     properties: {
@@ -56,6 +59,7 @@ const store = new Store({
     spellchecker: true,
     hardwareAcceleration: true,
     discordRpc: true,
+    homeserver: "",
     windowState: {
       isMaximised: false,
     },
@@ -74,6 +78,7 @@ class Config {
       spellchecker: this.spellchecker,
       hardwareAcceleration: this.hardwareAcceleration,
       discordRpc: this.discordRpc,
+      homeserver: this.homeserver,
       windowState: this.windowState,
     });
   }
@@ -162,6 +167,21 @@ class Config {
 
     (store as never as { set(k: string, value: boolean): void }).set(
       "discordRpc",
+      value,
+    );
+
+    this.sync();
+  }
+
+  get homeserver() {
+    return (store as never as { get(k: string): string }).get(
+      "homeserver",
+    );
+  }
+
+  set homeserver(value: string) {
+    (store as never as { set(k: string, value: string): void }).set(
+      "homeserver",
       value,
     );
 

--- a/src/world/config.ts
+++ b/src/world/config.ts
@@ -14,4 +14,7 @@ contextBridge.exposeInMainWorld("desktopConfig", {
   setAutostart(value: boolean) {
     ipcRenderer.send("setAutostart", value);
   },
+  setHomeserver(value: string) {
+    ipcRenderer.send("updateHomeserver", value);
+  }
 });


### PR DESCRIPTION
This is a _very_ rough implementation user changeable servers on the desktop app. References to the original URL are replaced with the config option `homeserver`.

If the app is launched with a blank string for `homeserver` (which is blank on config init), it prompts the user to input the server to use (the text field defaults to the original https://beta.revolt.chat). 
If the config option is populated it just loads the URL directly on startup, same as before.

I am not very familiar with Vite or how it integrates into Electron so apologies for the horrendous code, I tried to keep diffs to a minimum and only change what is absolutely required. 90% is one raw HTML file with some styling embedded lifted off the Stoat.chat site. Someone more familiar with Vite should really go through and make it pretty prior to merge. Same goes for the forge config.

Note: This implementation would benefit from the `for-web` package to also have a new config option for home server. Then users can change servers without modifying the config json.