### PR TITLE
fix: App Autostart

### DIFF
--- a/src/native/autoLaunch.ts
+++ b/src/native/autoLaunch.ts
@@ -8,16 +8,20 @@ export const autoLaunch = new AutoLaunch({
   name: "Stoat",
 });
 
-ipcMain.on("isAutostart?", () =>
-  autoLaunch
-    .isEnabled()
-    .then((enabled) => mainWindow.webContents.send("isAutostart", enabled)),
-);
+ipcMain.handle("getAutostart", async () => {
+  const enabled = await autoLaunch.isEnabled();
+  return enabled;
+});
 
-ipcMain.on("setAutostart", (_event, state: boolean) => {
+ipcMain.handle("setAutostart", async (_event, state: boolean) => {
   if (state) {
-    autoLaunch.enable();
+    await autoLaunch.enable();
+    console.log("Received new configuration autoStart: true");
   } else {
-    autoLaunch.disable();
+    await autoLaunch.disable();
+    console.log("Received new configuration autoStart: false");
   }
+
+  const enabled = await autoLaunch.isEnabled();
+  return enabled;
 });

--- a/src/world/config.ts
+++ b/src/world/config.ts
@@ -8,10 +8,9 @@ contextBridge.exposeInMainWorld("desktopConfig", {
   get: () => config,
   set: (config: DesktopConfig) => ipcRenderer.send("config", config),
   getAutostart() {
-    ipcRenderer.send("isAutostart?");
-    return new Promise((resolve) => ipcRenderer.once("isAutostart", resolve));
+    return ipcRenderer.invoke("getAutostart") as Promise<boolean>;
   },
   setAutostart(value: boolean) {
-    ipcRenderer.send("setAutostart", value);
+    return ipcRenderer.invoke("setAutostart", value) as Promise<boolean>;
   },
 });


### PR DESCRIPTION
- Switch autostart IPC to request/response (`invoke/handle`) so the UI can reliably read and update the setting.
- Return the updated autostart state after toggling to keep the checkbox/toggle in sync.

## Related Issues
- https://github.com/stoatchat/for-desktop/issues/10
- https://github.com/stoatchat/for-desktop/issues/14
- https://github.com/stoatchat/for-desktop/issues/44

## Notes
Before this change, autostart used fire-and-forget IPC plus a separate reply event, which could return before the setting actually changed. The new flow awaits a direct response with the updated state.

![YWxit6yIEs](https://github.com/user-attachments/assets/23ffb3ec-c48a-4742-9b39-6de5c23c66b4)
