### PR TITLE
fix: firstLaunch = false after initial setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { IUpdateInfo, updateElectronApp } from "update-electron-app";
 
-import { BrowserWindow, app, shell, Notification } from "electron";
+import { BrowserWindow, Notification, app, shell } from "electron";
 import started from "electron-squirrel-startup";
 
 import { autoLaunch } from "./native/autoLaunch";
@@ -26,29 +26,31 @@ const acquiredLock = app.requestSingleInstanceLock();
 
 const onNotifyUser = (_info: IUpdateInfo) => {
   const notification = new Notification({
-    title: 'Update Available',
-    body: 'Restart the app to install the update.',
-    silent: true
-  })
+    title: "Update Available",
+    body: "Restart the app to install the update.",
+    silent: true,
+  });
 
-  notification.show()
-}
+  notification.show();
+};
 
 if (acquiredLock) {
   // start auto update logic
-  updateElectronApp({onNotifyUser})
+  updateElectronApp({ onNotifyUser });
 
   // create and configure the app when electron is ready
   app.on("ready", () => {
+    // create window and application contexts
+    createMainWindow();
+
     // enable auto start on Windows and MacOS
     if (config.firstLaunch) {
       if (process.platform === "win32" || process.platform === "darwin") {
         autoLaunch.enable();
       }
+      config.firstLaunch = false;
     }
 
-    // create window and application contexts
-    createMainWindow();
     initTray();
     initDiscordRpc();
 


### PR DESCRIPTION
firstLaunch was never cleared so autoLaunch was called on each start wich caused the "auto start" toggle on