### PR TITLE
fix: flatpak icons not building correctly and wayland support

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -59,7 +59,14 @@ if (!process.env.PLATFORM) {
         productName: STRINGS.name,
         productDescription: STRINGS.description,
         runtimeVersion: "25.08",
-        icon: `${ASSET_DIR}/icon.png`,
+        icon: {
+          "16x16": `${ASSET_DIR}/hicolor/16x16.png`,
+          "32x32": `${ASSET_DIR}/hicolor/32x32.png`,
+          "64x64": `${ASSET_DIR}/hicolor/64x64.png`,
+          "128x128": `${ASSET_DIR}/hicolor/128x128.png`,
+          "256x256": `${ASSET_DIR}/hicolor/256x256.png`,
+          "512x512": `${ASSET_DIR}/hicolor/512x512.png`,
+        } as unknown,
         categories: ["Network"],
         modules: [
           // use the latest zypak -- Electron sandboxing for Flatpak
@@ -77,7 +84,7 @@ if (!process.env.PLATFORM) {
         finishArgs: [
           // default arguments found by running
           // DEBUG=electron-installer-flatpak* pnpm make
-          "--socket=x11",
+          "--socket=fallback-x11",
           "--share=ipc",
           "--device=dri",
           "--socket=pulseaudio",


### PR DESCRIPTION
This PR adds icons to the dev flatpak builder. Production is using flathub; however, as a self hoster, the flatpak is my preferred way to build and distribute my custom client to the linux users in my community. 

I answered the stack overflow post referenced in the commented out flatpak files code:
https://stackoverflow.com/questions/79745700/how-to-correctly-package-a-n-electron-app-into-a-flatpak-with-a-custom-app-icon/79891293#79891293

Also addressed the issue in electron-forge:
https://github.com/electron/forge/issues/2054#issuecomment-3918577638