### PR TITLE
feat: enable screen capture via setDisplayMediaRequestHandler

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -5,6 +5,7 @@ import {
   Menu,
   MenuItem,
   app,
+  desktopCapturer,
   ipcMain,
   nativeImage,
 } from "electron";
@@ -85,6 +86,25 @@ export function createMainWindow() {
 
   // load the entrypoint
   mainWindow.loadURL(BUILD_URL.toString());
+
+  // enable screen capture; on Linux desktopCapturer is used as useSystemPicker is unreliable
+  if (process.platform === "linux") {
+    mainWindow.webContents.session.setDisplayMediaRequestHandler(
+      async (_request, callback) => {
+        const sources = await desktopCapturer.getSources({
+          types: ["screen", "window"],
+        });
+        callback({ video: sources[0] });
+      },
+    );
+  } else {
+    mainWindow.webContents.session.setDisplayMediaRequestHandler(
+      (request, callback) => {
+        callback({ video: request.video });
+      },
+      { useSystemPicker: true },
+    );
+  }
 
   // minimise window to tray
   mainWindow.on("close", (event) => {


### PR DESCRIPTION
Enables screen capture support across platforms using Electron's setDisplayMediaRequestHandler.

On Linux, uses desktopCapturer to manually enumerate sources, as useSystemPicker is unreliable on that platform. On Windows and macOS, delegates to the OS native picker via useSystemPicker: true.

Note:
I am using this branch for web [stoatchat/for-web#847](https://github.com/stoatchat/for-web/pull/847) in order for video to be enabled. 