### PR TITLE
feat: allow copying images from native context menu

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -147,7 +147,7 @@ export function createMainWindow() {
   // configure spellchecker context menu
   mainWindow.webContents.on("context-menu", (_, params) => {
     const menu = new Menu();
-
+    if (params.isEditable) {
     // add all suggestions
     for (const suggestion of params.dictionarySuggestions) {
       menu.append(
@@ -178,6 +178,15 @@ export function createMainWindow() {
         click() {
           config.spellchecker = !config.spellchecker;
         },
+        }),
+      );
+    }
+
+    menu.append(
+      new MenuItem({
+        label: "Copy Image",
+        visible: params.hasImageContents,
+        click: () => mainWindow.webContents.copyImageAt(params.x, params.y),
       }),
     );
 


### PR DESCRIPTION
closes stoatchat/for-desktop#273

Also makes autocomplete suggestions only appear when the right clicked element is actually editable.