### PR TITLE
fix: skip maximise if starting to tray

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -79,7 +79,7 @@ export function createMainWindow() {
   }
 
   // maximise the window if it was maximised before
-  if (config.windowState.isMaximised) {
+  if (config.windowState.isMaximised && !startHidden) {
     mainWindow.maximize();
   }
 


### PR DESCRIPTION
This addresses the issue pointed out in <https://github.com/orgs/stoatchat/discussions/1248#discussioncomment-16022962> about app starting maximised even if start to tray was selected

- `main` <!-- branch-stack -->
  - \#183 :point\_left:
