### PR TITLE
feat: make debian package

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -15,8 +15,10 @@ import { FuseV1Options, FuseVersion } from "@electron/fuses";
 const STRINGS = {
   author: "Revolt Platforms LTD",
   name: "Stoat",
+  packageName: "stoat-for-desktop",
   execName: "stoat-desktop",
   description: "Open source user-first chat platform.",
+  homepage: "https://stoat.chat/"
 };
 
 const ASSET_DIR = "assets/desktop";
@@ -26,6 +28,7 @@ const ASSET_DIR = "assets/desktop";
  */
 const makers: ForgeConfig["makers"] = [
   new MakerSquirrel({
+    platforms: ["win32"],
     name: STRINGS.name,
     authors: STRINGS.author,
     // todo: hoist this
@@ -38,6 +41,21 @@ const makers: ForgeConfig["makers"] = [
     copyright: "Copyright (C) 2025 Revolt Platforms LTD",
   }),
   new MakerZIP({}),
+  new MakerDeb({
+    platforms: ["linux"],
+    name: STRINGS.packageName,
+    productName: STRINGS.name,
+    genericName: "Chat platform",
+    description: STRINGS.description,
+    // todo: productDescription (long description)
+    section: "net",
+    priority: "optional",
+    maintainer: STRINGS.author,
+    homepage: STRINGS.homepage,
+    bin: `${STRINGS.execName}`,
+    icon: `${ASSET_DIR}/icon.ico`,
+    categories: ["Network"],
+  })
 ];
 
 // skip these makers in CI/CD
@@ -116,15 +134,6 @@ if (!process.env.PLATFORM) {
         MakerFlatpakOptionsConfig,
         "files"
       > */
-    }),
-    // testing purposes
-    new MakerDeb({
-      options: {
-        productName: STRINGS.name,
-        productDescription: STRINGS.description,
-        categories: ["Network"],
-        icon: `${ASSET_DIR}/icon.png`,
-      },
     }),
   );
 }


### PR DESCRIPTION
This PR creates a debian package when building for linux platform.
Tested locally on Ubuntu with KDE, it works as expected with the same behaviour as the non-package version (zip).

Some notes:
* According to the [documentation](https://www.electronforge.io/config/makers/deb), debian packages can only be built on linux or macOS. Make sure to take this into consideration for CI/CD.
*  MakerZIP does not handle specific platforms, so a zip file will always be produced. But can be removed once all platforms are supported.
* The debian package requirements mentions `kde-runtime`. I'm not sure why, maybe it is because I built from a KDE environment? Might need to test this on a different distro and different desktop environment.
* Feel free to fill the `productDescription` option. This is supposed to be the long description of the application.
* I believe the maintainer field requires an email. You might want to add it as `Revolt Platforms LTD <email@mail.com>`
* Copyright  information should be provided with a `copyright` file in the package. See https://www.debian.org/doc/debian-policy/ch-archive.html#copyright-considerations for more information.

Here is the package info:
>  new Debian package, version 2.0.
 size 83213716 bytes: control archive=552 bytes.
     503 bytes,    13 lines      control
 Package: stoat-for-desktop
 Version: 1.3.0
 Section: net
 Priority: optional
 Architecture: amd64
 Depends: libgtk-3-0, libnotify4, libnss3, xdg-utils, libatspi2.0-0, libdrm2, libgbm1, libxcb-dri3-0, kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin
 Recommends: pulseaudio | libasound2
 Suggests: gir1.2-gnomekeyring-1.0, libgnome-keyring0, lsb-release
 Installed-Size: 292530
 Maintainer: Revolt Platforms LTD
 Homepage: https://stoat.chat/
 Description: Open source user-first chat platform.