### PR TITLE
fix(flatpak): change screenshot path into an url in the metainfo file

### DIFF
--- a/chat.stoat.StoatDesktop.metainfo.xml
+++ b/chat.stoat.StoatDesktop.metainfo.xml
@@ -19,7 +19,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>Main window</caption>
-      <image>screenshot.png</image>
+      <image>https://raw.githubusercontent.com/stoatchat/for-desktop/b57faa2c59865fea15a879c9a9304271067d0020/screenshot.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
This is to fix the issue here: https://github.com/flathub/flathub/pull/7783#issuecomment-4107156777

Where it fails in the flathub build with
```
Error: Appstream: 'E:chat.stoat.StoatDesktop.metainfo.xml:web-url-expected:22 A web URL was expected for this value.'
```