### PR TITLE
feat: Devtools keybinds, config.enableDevtoolsUntilTimestamp + bypass flag

### DIFF
--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -5,6 +5,7 @@ declare type DesktopConfig = {
   spellchecker: boolean;
   hardwareAcceleration: boolean;
   discordRpc: boolean;
+  enableDevtoolsUntilTimestamp: number;
   windowState: {
     x: number;
     y: number;

--- a/src/native/config.ts
+++ b/src/native/config.ts
@@ -60,6 +60,7 @@ const store = new Store({
     spellchecker: true,
     hardwareAcceleration: true,
     discordRpc: true,
+    enableDevtoolsUntilTimestamp: 0,
     windowState: {
       x: 0,
       y: 0,
@@ -83,6 +84,7 @@ class Config {
       spellchecker: this.spellchecker,
       hardwareAcceleration: this.hardwareAcceleration,
       discordRpc: this.discordRpc,
+      enableDevtoolsUntilTimestamp: this.enableDevtoolsUntilTimestamp,
       windowState: this.windowState,
     });
   }
@@ -186,6 +188,19 @@ class Config {
 
     (store as never as { set(k: string, value: boolean): void }).set(
       "discordRpc",
+      value,
+    );
+
+    this.sync();
+  }
+
+  get enableDevtoolsUntilTimestamp() {
+    return (store as never as { get(k: string): number }).get("discordRpc");
+  }
+
+  set enableDevtoolsUntilTimestamp(value: number) {
+    (store as never as { set(k: string, value: number): void }).set(
+      "enableDevtoolsUntilTimestamp",
       value,
     );
 

--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -14,6 +14,13 @@ import windowIconAsset from "../../assets/desktop/icon.png?asset";
 import { config } from "./config";
 import { updateTrayMenu } from "./tray";
 
+// Surprisingly, I am having a lot of trouble figuring out what to name this?
+// I want the warning to actually warn the end user instead of just being a
+// very generic "I know what I am doing" dialog that is instinctively skipped.
+const bypassDevtoolsExpirationSetting = process.argv.includes(
+  "--bypass-devtools-expiration-and-i-am-not-being-told-to-paste-scripts"
+);
+
 // global reference to main window
 export let mainWindow: BrowserWindow;
 
@@ -138,6 +145,28 @@ export function createMainWindow() {
     ) {
       event.preventDefault();
       mainWindow.webContents.reload();
+    }
+  });
+
+  // Afaik, this is the easiest way to let the app
+  // turn the keybinds for opening devtools on/off.
+  // Adapted from: https://stackoverflow.com/a/75716165
+  mainWindow.webContents.on("before-input-event", (_, input) => {
+    if (input.type !== "keyDown") {
+      return;
+    }
+
+    const devtoolsExpired = config.enableDevtoolsUntilTimestamp < Date.now();
+    if (devtoolsExpired && !bypassDevtoolsExpirationSetting) {
+      config.enableDevtoolsUntilTimestamp = 0;
+      return;
+    }
+
+    // `input.key`, for letters, is UPPERCASE if shift is pressed, lowercase otherwise.
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+    const ctrlShiftI = input.control && input.key === "I";
+    if (ctrlShiftI || input.key === "F12") {
+      mainWindow.webContents.toggleDevTools();
     }
   });
 


### PR DESCRIPTION
This PR adds the `Ctrl + Shift + I` and `F12` keybinds that conditionally open devtools.

"Conditionally", because there is `config.enableDevtoolsUntilTimestamp`.

If `Date.now()` is higher than that timestamp, the keybinds will not work, unless you use the command line flag to bypass it, which lets you use the keybinds all the time.

The command line flag is `--bypass-devtools-expiration-and-i-am-not-being-told-to-paste-scripts`.
It *is that* so scammers don't use the flag to bypass any safety warnings from the settings menus, although there would still be the scammer telling you to screenshot the networking tab and I don't know if there is a limit for command line flags or if I can just make it something ridiculous like
`--bypass-devtools-expiration-and-i-am-not-being-told-to-paste-scripts-or-screenshot-the-networking-tab`