### PR TITLE
style: use macos native traffic lights

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -41,6 +41,7 @@ export function createMainWindow() {
   // (CLI arg --hidden or config)
   const startHidden =
     app.commandLine.hasSwitch("hidden") || config.startMinimisedToTray;
+  const isMacOS = process.platform === "darwin";
 
   // create the window
   mainWindow = new BrowserWindow({
@@ -49,7 +50,9 @@ export function createMainWindow() {
     width: 1280,
     height: 720,
     backgroundColor: "#191919",
-    frame: !config.customFrame,
+    frame: isMacOS ? true : !config.customFrame,
+    titleBarStyle: isMacOS ? "hidden" : "default",
+    trafficLightPosition: isMacOS ? { x: 8, y: 8 } : undefined,
     icon: windowIcon,
     show: !startHidden,
     webPreferences: {


### PR DESCRIPTION
The macOS app uses its own controls in the title bar. Because many macOS apps uses native "trafic lights" in the top-left of the window, it can possibly be seen inconsistent.

This PR changes title bar UI and these changes only apply in macOS.

Because both `for-web` and `for-desktop` need to be updated, **you have to merge both requests at the same time**. (https://github.com/stoatchat/for-web/pull/1274, https://github.com/stoatchat/for-desktop/pull/220)

Thanks.

### Original version:
<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 10 04 AM" src="https://github.com/user-attachments/assets/e8552b0e-b272-4588-8a19-60cba32c672d" />

<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 16 02 AM" src="https://github.com/user-attachments/assets/3763ea30-fa65-4bac-b7ae-1c397280bcd4" />


### Updated version:
<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 10 25 AM" src="https://github.com/user-attachments/assets/3fa5a915-be07-43b6-a1cd-73056719ed42" />

<img width="955" height="606" alt="Screenshot 2026-06-14 at 6 15 40 AM" src="https://github.com/user-attachments/assets/3a427e2b-b515-469a-8d0a-94d3b4e57bbd" />
