### PR TITLE
fix: make electron use loopback instead of loopbackwithmute

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -204,7 +204,7 @@ export function createMainWindow() {
             // See vencord for an implementation using a virtual microphone.
             callback({
               video: sources[0],
-              audio: request.audioRequested ? "loopbackWithMute" : undefined,
+              audio: request.audioRequested ? "loopback" : undefined,
             });
             return;
           }
@@ -216,7 +216,7 @@ export function createMainWindow() {
               } else {
                 callback({
                   video: sources[idx],
-                  audio: audio ? "loopbackWithMute" : undefined,
+                  audio: audio ? "loopback" : undefined,
                 });
               }
             },


### PR DESCRIPTION
I made an assumption in the screen share PR that was incorrect. LoopbackWithMute causes the system to be muted on windows, and breaks pipewire on wayland. This PR changes it back to Loopback which works on both.

Fixes #225
Fixes #229

- `main` <!-- branch-stack -->
  - \#236 :point\_left:
