### PR TITLE
fix: Use liquid glass icon on MacOS

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -124,7 +124,9 @@ const config: ForgeConfig = {
     asar: true,
     name: STRINGS.name,
     executableName: STRINGS.execName,
-    icon: `${ASSET_DIR}/icon`,
+    icon: process.platform === "darwin" 
+      ? `${ASSET_DIR}/icon.icon` 
+      : `${ASSET_DIR}/icon`,
     // extraResource: [
     //   // include all the asset files
     //   ...globSync(ASSET_DIR + "/**/*"),


### PR DESCRIPTION
I updated the Assets submodule and adjusted some of the packaging code, so that it will use a Liquid Glass icon on MacOS.