### PR TITLE
fix: Add Mic and Webcam Entitlements

### DIFF
--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -127,6 +127,14 @@ const config: ForgeConfig = {
     icon: process.platform === "darwin" 
       ? `${ASSET_DIR}/icon.icon` 
       : `${ASSET_DIR}/icon`,
+    osxSign: {
+      optionsForFile: () => {
+        return {
+          entitlements: './entitlements.plist'
+        };
+      }
+    }
+
     // extraResource: [
     //   // include all the asset files
     //   ...globSync(ASSET_DIR + "/**/*"),


### PR DESCRIPTION
Before, Stoat will NOT ask you if you want to use a mic or webcam. Instead, it fails silently.

I've added an entitlements.plist file that makes this work.