### PR TITLE
fix: What if we just reloaded every startup, would that kill cache?

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -89,7 +89,9 @@ export function createMainWindow() {
   }
 
   // load the entrypoint
-  mainWindow.loadURL(BUILD_URL.toString());
+  mainWindow
+    .loadURL(BUILD_URL.toString())
+    .then(() => mainWindow.webContents.reload());
 
   // minimise window to tray
   mainWindow.on("close", (event) => {


### PR DESCRIPTION
maybe this fix the grey screen bug.

More details:

Chromium, and by extension Electron, will not reload the page when it is not navigated to manually. This means that the app will bring up the same index.html version every time no matter what. In theory, this reload call should make the app reload the page on every startup.

- `main` <!-- branch-stack -->
  - \#269 :point\_left:
