### PR TITLE
fix: restore dropped IPC handlers and fix several main-process bugs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { IUpdateInfo, updateElectronApp } from "update-electron-app";
 import { BrowserWindow, Notification, app, shell } from "electron";
 import started from "electron-squirrel-startup";
 
+import { initAutoLaunch } from "./native/autoLaunch";
+import { initBadges } from "./native/badges";
 import { config } from "./native/config";
 import { initDiscordRpc } from "./native/discordRpc";
 import { initTray } from "./native/tray";
@@ -40,6 +42,11 @@ if (acquiredLock) {
 
   // create and configure the app when electron is ready
   app.on("ready", () => {
+    // register IPC handlers before the window exists, so they are always in
+    // place by the time the renderer loads and starts calling into them
+    initAutoLaunch();
+    initBadges();
+
     // create window and application contexts
     createMainWindow();
 

--- a/src/native/autoLaunch.ts
+++ b/src/native/autoLaunch.ts
@@ -6,20 +6,26 @@ export const autoLaunch = new AutoLaunch({
   name: "Stoat",
 });
 
-ipcMain.handle("getAutostart", async () => {
-  const enabled = await autoLaunch.isEnabled();
-  return enabled;
-});
+/**
+ * Register the auto launch IPC handlers.
+ *
+ * These used to be registered as an import side effect, which meant they were
+ * silently dropped once the last direct use of `autoLaunch` disappeared and
+ * linting removed the then-unused import. Requiring an explicit call keeps the
+ * handlers tied to something the linter cannot quietly delete.
+ */
+export function initAutoLaunch() {
+  ipcMain.handle("getAutostart", () => autoLaunch.isEnabled());
 
-ipcMain.handle("setAutostart", async (_event, state: boolean) => {
-  if (state) {
-    await autoLaunch.enable();
-    console.log("Received new configuration autoStart: true");
-  } else {
-    await autoLaunch.disable();
-    console.log("Received new configuration autoStart: false");
-  }
+  ipcMain.handle("setAutostart", async (_event, state: boolean) => {
+    if (state) {
+      await autoLaunch.enable();
+    } else {
+      await autoLaunch.disable();
+    }
 
-  const enabled = await autoLaunch.isEnabled();
-  return enabled;
-});
+    console.log(`Received new configuration autoStart: ${state}`);
+
+    return autoLaunch.isEnabled();
+  });
+}

--- a/src/native/badges.ts
+++ b/src/native/badges.ts
@@ -66,4 +66,17 @@ export async function setBadgeCount(count: number) {
   }
 }
 
-ipcMain.on("setBadgeCount", (_event, count: number) => setBadgeCount(count));
+/**
+ * Register the badge count IPC handler.
+ *
+ * The renderer has been able to call `native.setBadgeCount` since the preload
+ * bridge was added, but nothing ever imported this module, so the main process
+ * never listened for it and taskbar badges silently did nothing.
+ */
+export function initBadges() {
+  ipcMain.on("setBadgeCount", (_event, count: number) =>
+    setBadgeCount(count).catch((err) =>
+      console.error("Failed to set badge count", err),
+    ),
+  );
+}

--- a/src/native/config.ts
+++ b/src/native/config.ts
@@ -148,12 +148,14 @@ class Config {
   }
 
   set spellchecker(value: boolean) {
-    mainWindow.webContents.session.setSpellCheckerEnabled(value);
-
+    // persist before applying, so a failure to reach the window cannot lose the
+    // preference the user just set
     (store as never as { set(k: string, value: boolean): void }).set(
       "spellchecker",
       value,
     );
+
+    mainWindow.webContents.session.setSpellCheckerEnabled(value);
 
     this.sync();
   }
@@ -178,16 +180,19 @@ class Config {
   }
 
   set discordRpc(value: boolean) {
+    // persist before acting on it: `initDiscordRpc` reads this setting back out
+    // of the store, so running it first made it observe the previous value and
+    // bail out, leaving RPC off until the app was restarted
+    (store as never as { set(k: string, value: boolean): void }).set(
+      "discordRpc",
+      value,
+    );
+
     if (value) {
       initDiscordRpc();
     } else {
       destroyDiscordRpc();
     }
-
-    (store as never as { set(k: string, value: boolean): void }).set(
-      "discordRpc",
-      value,
-    );
 
     this.sync();
   }

--- a/src/native/discordRpc.ts
+++ b/src/native/discordRpc.ts
@@ -3,42 +3,86 @@ import { Client } from "discord-rpc";
 import { config } from "./config";
 
 // internal state
-let rpc: Client;
+let rpc: Client | undefined;
+let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Drop the current client and cancel any pending reconnect.
+ *
+ * Detaching the listeners before destroying matters: `destroy` makes the client
+ * emit `disconnected`, which would otherwise schedule a reconnect for the
+ * client we are in the middle of throwing away.
+ */
+function teardown() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+  }
+
+  const client = rpc;
+  rpc = undefined;
+
+  if (!client) return;
+
+  client.removeAllListeners();
+
+  try {
+    // rejects when the transport never connected in the first place
+    const destroyed = client.destroy() as unknown;
+    if (destroyed instanceof Promise) destroyed.catch(() => undefined);
+  } catch {
+    // nothing to tear down
+  }
+}
+
+function reconnect() {
+  if (reconnectTimer) return;
+
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = undefined;
+    initDiscordRpc();
+  }, 1e4);
+}
 
 export async function initDiscordRpc() {
   if (!config.discordRpc) return;
 
-  // clean up existing client if one exists
-  rpc?.removeAllListeners();
+  // tear down any existing client, otherwise it stays logged in to Discord and
+  // keeps broadcasting the activity even after the user turns the setting off
+  teardown();
+
+  const client = new Client({ transport: "ipc" });
+  rpc = client;
+
+  client.on("ready", () =>
+    client.setActivity({
+      state: "stoat.chat",
+      details: "Chatting with others",
+      largeImageKey: "qr",
+      largeImageText: "Join Stoat!",
+      buttons: [
+        {
+          label: "Join Stoat",
+          url: "https://stoat.chat/",
+        },
+      ],
+    }),
+  );
+
+  client.on("disconnected", () => {
+    // ignore clients we have already replaced or discarded
+    if (rpc === client) reconnect();
+  });
 
   try {
-    rpc = new Client({ transport: "ipc" });
-
-    rpc.on("ready", () =>
-      rpc.setActivity({
-        state: "stoat.chat",
-        details: "Chatting with others",
-        largeImageKey: "qr",
-        largeImageText: "Join Stoat!",
-        buttons: [
-          {
-            label: "Join Stoat",
-            url: "https://stoat.chat/",
-          },
-        ],
-      }),
-    );
-
-    rpc.on("disconnected", reconnect);
-
-    rpc.login({ clientId: "872068124005007420" });
-  } catch (err) {
-    reconnect();
+    // `login` is asynchronous; awaiting it here keeps a missing Discord client
+    // from surfacing as an unhandled rejection and lets us retry
+    await client.login({ clientId: "872068124005007420" });
+  } catch {
+    if (rpc === client) reconnect();
   }
 }
 
-const reconnect = () => setTimeout(() => initDiscordRpc(), 1e4);
-
 export async function destroyDiscordRpc() {
-  rpc?.destroy();
+  teardown();
 }

--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -8,6 +8,7 @@ import {
   desktopCapturer,
   ipcMain,
   nativeImage,
+  screen,
   session,
 } from "electron";
 
@@ -29,10 +30,38 @@ export const BUILD_URL = new URL(
 // internal window state
 let shouldQuit = false;
 
+// how much of the window has to land on a display for it to count as reachable
+const MIN_VISIBLE_PIXELS = 100;
+
 // load the window icon
 const windowIcon = nativeImage.createFromDataURL(windowIconAsset);
 
 // windowIcon.setTemplateImage(true);
+
+/**
+ * Check whether a saved window rectangle still overlaps a connected display.
+ *
+ * Monitors get unplugged and resolutions change between launches, so a stored
+ * position can easily point somewhere that no longer exists.
+ */
+function isOnScreen(bounds: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}) {
+  return screen.getAllDisplays().some(({ workArea }) => {
+    const overlapX =
+      Math.min(bounds.x + bounds.width, workArea.x + workArea.width) -
+      Math.max(bounds.x, workArea.x);
+
+    const overlapY =
+      Math.min(bounds.y + bounds.height, workArea.y + workArea.height) -
+      Math.max(bounds.y, workArea.y);
+
+    return overlapX >= MIN_VISIBLE_PIXELS && overlapY >= MIN_VISIBLE_PIXELS;
+  });
+}
 
 /**
  * Create the main application window
@@ -60,27 +89,44 @@ export function createMainWindow() {
       preload: join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
-      spellcheck: true,
+      spellcheck: config.spellchecker,
     },
   });
 
   // hide the options
   mainWindow.setMenu(null);
 
-  // restore last position if it was moved previously
-  if (config.windowState.x > 0 || config.windowState.y > 0) {
-    mainWindow.setPosition(
-      config.windowState.x ?? 0,
-      config.windowState.y ?? 0,
-    );
-  }
+  // apply the stored spellchecker preference; the setter only runs when the
+  // user toggles it, so without this the setting reverted on every launch
+  mainWindow.webContents.session.setSpellCheckerEnabled(config.spellchecker);
 
   // restore last size if it was resized previously
+  // (before the position, which is validated against the resulting size)
   if (config.windowState.width > 0 && config.windowState.height > 0) {
     mainWindow.setSize(
       config.windowState.width ?? 1280,
       config.windowState.height ?? 720,
     );
+  }
+
+  // restore last position if it was moved previously, but only when it still
+  // lands on a display; otherwise the window opens somewhere unreachable after
+  // a monitor is unplugged or rearranged
+  // (negative coordinates are valid: displays can sit left of / above the primary one)
+  if (config.windowState.x !== 0 || config.windowState.y !== 0) {
+    const [width, height] = mainWindow.getSize();
+    const bounds = {
+      x: config.windowState.x ?? 0,
+      y: config.windowState.y ?? 0,
+      width,
+      height,
+    };
+
+    if (isOnScreen(bounds)) {
+      mainWindow.setPosition(bounds.x, bounds.y);
+    } else {
+      mainWindow.center();
+    }
   }
 
   // maximise the window if it was maximised before
@@ -212,10 +258,18 @@ export function createMainWindow() {
                 });
             return;
           }
+          // drop any listener left over from a picker the user dismissed
+          // without choosing a source: it would consume this request's reply
+          // and hand it to a request that is already dead, leaving screen
+          // sharing broken until the app is restarted
+          ipcMain.removeAllListeners("screenPickerCallback");
+
           ipcMain.once(
             "screenPickerCallback",
             (_, idx: number, audio: boolean) => {
-              if (idx < 0 || idx > sources.length) {
+              // `idx === sources.length` is out of bounds and used to hand
+              // `undefined` to the callback as if it were a valid source
+              if (idx < 0 || idx >= sources.length) {
                 callback({});
               } else {
                 audio
@@ -232,13 +286,14 @@ export function createMainWindow() {
           mainWindow.webContents.send(
             "screenPicker",
             sources.map((source, idx) => {
-              const image = source.appIcon;
+              let image = source.appIcon;
+              // `resize` returns a new image rather than mutating in place, so
+              // discarding the result sent the full-size icon over IPC instead
               if (image) {
-                if (image.getAspectRatio() > 1) {
-                  image.resize({ width: 256 });
-                } else {
-                  image.resize({ height: 256 });
-                }
+                image =
+                  image.getAspectRatio() > 1
+                    ? image.resize({ width: 256 })
+                    : image.resize({ height: 256 });
               }
               return {
                 idx: idx,
@@ -248,6 +303,12 @@ export function createMainWindow() {
               };
             }),
           );
+        })
+        .catch((err) => {
+          // always answer the request, otherwise the renderer waits forever
+          console.error("Failed to enumerate screen capture sources", err);
+          ipcMain.removeAllListeners("screenPickerCallback");
+          callback({});
         });
     },
     { useSystemPicker: true },


### PR DESCRIPTION
Six main-process bugs, three of which have open issues that turn out to have the same root cause: **an IPC handler that is not registered at runtime**.

### 1. Autostart and badge IPC handlers were never registered

`native/autoLaunch.ts` and `native/badges.ts` register their handlers as an *import side effect*, and nothing imports either module.

For autostart this is a **regression in 1.5.0**:

- e00f3a8 (#237) removed the last direct use of `autoLaunch`, leaving the import unused
- 6894231 (#252) then removed the now-unused import during the lint pass

`ipcMain.handle("getAutostart"/"setAutostart")` went with it, so `desktopConfig.setAutostart()` rejects with *"No handler registered"* and the settings toggle silently does nothing — matching #287 exactly ("I had removed the option for Stoat to auto start in the options menu. However it still auto started. I verified that the windows startup option was still ticked").

Badges were never wired up at all: `git log -S 'native/badges'` shows the module has not been imported since the initial commit, even though the preload bridge has exposed `native.setBadgeCount()` since #25.

Verifiable on the current `main`:

```console
$ pnpm package && grep -c 'getAutostart\|setBadgeCount' .vite/build/main.js
0
```

Both modules now expose an explicit `init*()` called from `main.ts`, so registration is tied to a call site the linter cannot quietly drop.

Closes #287. Refs #213 — this only restores the plumbing; the UX described in that issue still needs client-side work.

### 2. Discord RPC (refs #203)

- **Turning it on did nothing.** The `discordRpc` setter ran `initDiscordRpc()` *before* writing the new value to the store, and `initDiscordRpc` reads that setting back out of the store — so it observed the stale value and took the `if (!config.discordRpc) return` early exit. The setters now persist first and act second.
- **Turning it off left the old client running.** `initDiscordRpc` only called `removeAllListeners()` on the previous client and never destroyed it, so every toggle stacked another client that stayed logged in to Discord and kept broadcasting the activity.
- `login()` is asynchronous, so its rejection escaped the `try`/`catch` as an unhandled rejection and never triggered a retry.
- `destroy()` rejects when the transport never connected, which is now swallowed rather than surfacing as an unhandled rejection.
- `disconnected` only schedules a reconnect for the client that is still current, and reconnects no longer stack.

### 3. Spellchecker not applied on launch (refs #69)

`webPreferences.spellcheck` was hardcoded to `true` and `setSpellCheckerEnabled` only ever ran from the setter, so the stored preference was never applied at startup — disabling it silently reverted on the next launch.

### 4. Screen sharing breaks after a cancelled picker (refs #267, #263)

`screenPickerCallback` is registered with `ipcMain.once`, so a picker the user dismissed without choosing a source leaves it attached forever. The next screen share request registers a second listener *behind* the stale one, which then consumes the reply and hands it to a request that is already dead — leaving screen sharing broken until the app restarts. Stale listeners are now cleared before registering, mirroring what the renderer side already does in `world/window.ts`.

Alongside it:

- the bounds check rejected `idx < 0 || idx > sources.length`, so `idx === sources.length` passed and `sources[idx]` handed `undefined` to the callback as if it were a real source
- `getSources()` had no rejection path, so a failure left the renderer waiting on a callback that was never invoked
- `NativeImage.resize()` returns a new image instead of mutating in place, so discarding the result sent full-size icons over IPC

### 5. Window restored onto a disconnected display (refs #176)

The saved position was restored without checking that it still lands on a connected display, so unplugging or rearranging a monitor left the window opening off screen with no way to reach it. It now falls back to centring the window.

The guard also changes from `x > 0 || y > 0` to `x !== 0 || y !== 0`, since negative coordinates are legitimate for displays positioned left of or above the primary one.

---

### Testing

`mise lint`, `mise format` and `mise build` all pass.

I have **not** exercised these interactively — no manual autostart, screen share or RPC run — so runtime confirmation from someone on each platform would be welcome, particularly the screen picker path. The autostart and badge handlers are confirmed by diffing the packaged bundle before and after (0 → 1 occurrences of each handler, plus the 12 badge assets now resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
